### PR TITLE
fix: RPC status remains stuck on Discord after closing Adobe app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,11 @@ function main() {
     })
 
     rpc.login(() => stateEvent.dispatchEvent())
+
+    const csInterface = new CSInterface()
+    csInterface.addEventListener(CSInterface.ADOBE_APPLICATION_BEFORE_APPCLOSE, () => {
+        try { rpc.client.destroy() } catch(e) {}
+    })
 }
 
 

--- a/src/services/adobe/adobeRPC.js
+++ b/src/services/adobe/adobeRPC.js
@@ -95,11 +95,20 @@ class AdobeRPC {
     }
 
     logout() {
-        this.client.destroy().then(() => {
+        this.client.clearActivity().then(() => {
+            return this.client.destroy()
+        }).then(() => {
             clearInterval(this.interval)
+            this.stateManager.rpcConnection = 'disconnected'
+            this.callback()
             console.log('[AdobeRPC:logout] Successfully logout and clear interval')
+        }).catch((err) => {
+            console.log('[AdobeRPC:logout] Error: ' + err)
+            clearInterval(this.interval)
+            this.stateManager.rpcConnection = 'disconnected'
+            this.callback()
         })
-
+        
     }
 
     executeScript(props, func) {


### PR DESCRIPTION
## Bug
When closing the Adobe application, the Discord Rich Presence status remains frozen on the profile instead of disappearing.

## Changes
- `adobeRPC.js`: Call `clearActivity()` before `destroy()` on logout to properly clear the Discord status when turning off the extension
- `index.js`: Use `ADOBE_APPLICATION_BEFORE_APPCLOSE` event to destroy the RPC client when Adobe closes, preventing the status from getting stuck

## Tested on
- After Effects on Windows 11 (26200.8117)