### PR TITLE
refactor: implement event driven architecture to AdobeRPC and StateManager

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+import js from "@eslint/js";
+import globals from "globals";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: { 
+    CSInterface: "readonly",
+    CSEvent: "readonly",
+    ...globals.node, 
+    ...globals.browser 
+  } } },
+]);

--- a/package.json
+++ b/package.json
@@ -27,12 +27,15 @@
     "zxp-sign-cmd": "^2.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@parcel/config-default": "^2.16.0",
     "@parcel/core": "^2.16.0",
     "@parcel/plugin": "^2.16.0",
     "buffer": "^6.0.3",
     "chokidar": "^4.0.3",
+    "eslint": "^10.2.0",
     "events": "^3.3.0",
+    "globals": "^17.5.0",
     "parcel": "^2.16.0",
     "process": "^0.11.10",
     "shx": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.2.0)
       '@parcel/config-default':
         specifier: ^2.16.0
         version: 2.16.0(@parcel/core@2.16.0(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)
@@ -33,9 +36,15 @@ importers:
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
+      eslint:
+        specifier: ^10.2.0
+        version: 10.2.0
       events:
         specifier: ^3.3.0
         version: 3.3.0
+      globals:
+        specifier: ^17.5.0
+        version: 17.5.0
       parcel:
         specifier: ^2.16.0
         version: 2.16.0(@swc/helpers@0.5.17)
@@ -50,6 +59,61 @@ importers:
         version: 2.0.12
 
 packages:
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -591,9 +655,31 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -633,6 +719,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -656,6 +746,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -727,6 +821,18 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -766,6 +872,52 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.2.0:
+    resolution: {integrity: sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -781,6 +933,9 @@ packages:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
@@ -788,8 +943,18 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -797,6 +962,17 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -817,6 +993,10 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
@@ -824,6 +1004,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@17.5.0:
+    resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
+    engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -838,6 +1022,14 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -883,14 +1075,30 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -966,6 +1174,10 @@ packages:
     resolution: {integrity: sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==}
     hasBin: true
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -979,6 +1191,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -995,12 +1211,18 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   msgpackr-extract@3.0.3:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
     hasBin: true
 
   msgpackr@1.11.5:
     resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -1048,12 +1270,24 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ordered-binary@1.6.0:
     resolution: {integrity: sha512-IQh2aMfMIDbPjI/8a3Edr+PiOpcsB7yo8NdW7aHWVaoR/pcDldunMvnnwbk/auPGqmKeAdxtZl7MHX/QmPwhvQ==}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1062,6 +1296,10 @@ packages:
     resolution: {integrity: sha512-4sgnoYixTR6Qq6265tjmufXQj7wxvZo4VJHrYfbnfWQWfW5CgF80IiM+dy050pYgtBAMvh+8vJDDYiSto1YPUA==}
     engines: {node: '>= 16.0.0'}
     hasBin: true
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@2.0.1:
     resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
@@ -1088,6 +1326,10 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -1097,6 +1339,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1254,6 +1500,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -1263,6 +1513,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1289,6 +1542,10 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1312,6 +1569,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
@@ -1325,6 +1586,51 @@ packages:
     engines: {node: '>=12.0.0', npm: '>=6.0.0'}
 
 snapshots:
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.0)':
+    dependencies:
+      eslint: 10.2.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.5.5':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.2.0)':
+    optionalDependencies:
+      eslint: 10.2.0
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2103,9 +2409,28 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
@@ -2146,6 +2471,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   base-x@3.0.11:
@@ -2164,6 +2491,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -2238,6 +2569,12 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
   detect-libc@1.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -2273,6 +2610,72 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.2.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
   event-target-shim@5.0.1: {}
 
   events-universal@1.0.1:
@@ -2293,6 +2696,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-eof: 1.0.0
 
+  fast-deep-equal@3.1.3: {}
+
   fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
@@ -2303,9 +2708,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
 
   file-uri-to-path@1.0.0:
     optional: true
@@ -2313,6 +2726,18 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -2331,6 +2756,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -2344,6 +2773,8 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  globals@17.5.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
@@ -2353,6 +2784,10 @@ snapshots:
       function-bind: 1.1.2
 
   ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
+
+  imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
 
@@ -2386,11 +2821,26 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json5@2.2.3: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
 
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -2456,6 +2906,10 @@ snapshots:
       '@lmdb/lmdb-linux-x64': 2.8.5
       '@lmdb/lmdb-win32-x64': 2.8.5
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash@4.17.23: {}
 
   lru-cache@10.4.3: {}
@@ -2466,6 +2920,10 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
 
   minimatch@5.1.6:
     dependencies:
@@ -2478,6 +2936,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  ms@2.1.3: {}
 
   msgpackr-extract@3.0.3:
     dependencies:
@@ -2494,6 +2954,8 @@ snapshots:
   msgpackr@1.11.5:
     optionalDependencies:
       msgpackr-extract: 3.0.3
+
+  natural-compare@1.4.0: {}
 
   nice-try@1.0.5: {}
 
@@ -2531,9 +2993,26 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ordered-binary@1.6.0: {}
 
   p-finally@1.0.0: {}
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
 
@@ -2558,6 +3037,8 @@ snapshots:
       - '@swc/helpers'
       - napi-wasm
 
+  path-exists@4.0.0: {}
+
   path-key@2.0.1: {}
 
   path-key@3.1.1: {}
@@ -2575,6 +3056,8 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  prelude-ls@1.2.1: {}
+
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
@@ -2583,6 +3066,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -2748,6 +3233,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-fest@0.20.2: {}
 
   update-browserslist-db@1.1.4(browserslist@4.27.0):
@@ -2755,6 +3244,10 @@ snapshots:
       browserslist: 4.27.0
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
 
@@ -2777,6 +3270,8 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -2792,6 +3287,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.10: {}
+
+  yocto-queue@0.1.0: {}
 
   zip-stream@6.0.1:
     dependencies:

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,3 +1,5 @@
+import path from 'path'
+
 export const bundleName = "com.kureichi.discordrpc"
 
 export const distFolderPath = "./dist"
@@ -6,4 +8,4 @@ export const outputExtensionZipPath = `${distFolderPath}/${bundleName}.zip`
 export const outputCertPath = `${distFolderPath}/cert.p12`
 export const outputExtensionZxpPath = `${distFolderPath}/${bundleName}.zxp`
 
-export const symlinkTarget = `C:/Program Files (x86)/Common Files/Adobe/CEP/extensions/${bundleName}`
+export const symlinkTarget = path.join(process.env.APPDATA, 'Adobe', 'CEP', 'extensions', `${bundleName}`)

--- a/src/index.js
+++ b/src/index.js
@@ -3,29 +3,32 @@ import StateEvent from "./services/event/stateEvent"
 import StateManager from "./model/stateManager"
 import VersionCheck from "./services/github/versionCheck"
 
-function main() {
+async function main() {
+    const csInterface = new CSInterface()
     const versionCheck = new VersionCheck()
-
     const stateManager = new StateManager(localStorage)
     const rpc = new AdobeRPC(stateManager)
-    const stateEvent = new StateEvent(stateManager)
+    stateManager.init()
 
-    stateEvent.registerListener(() => [
-        rpc.reload()
-    ])
-
-    versionCheck.check((string) => {
-        console.log('[MAIN] Checked version : ' + string)
-
-        stateManager.versionInfo = string
-        stateEvent.dispatchEvent()
+    const stateEvent = new StateEvent(stateManager, csInterface)
+    const versionInfo = await versionCheck.getVersion()
+    stateManager.setState({ versionInfo: versionInfo })
+    
+    stateEvent.registerListener()
+    stateEvent.on('stateFromView', (state) => {
+        stateManager.setState(state)
     })
 
-    rpc.login(() => stateEvent.dispatchEvent())
+    rpc.on('adobeInfoChange', (info) => {
+        stateManager.setState(info)
+    })
+    rpc.on('connectionChange', (connection) => {
+        stateManager.setState({ rpcConnection: connection })
+    })
+    rpc.startService()
 
-    const csInterface = new CSInterface()
     csInterface.addEventListener(CSInterface.ADOBE_APPLICATION_BEFORE_APPCLOSE, () => {
-        try { rpc.client.destroy() } catch(e) {}
+        rpc.logout()
     })
 }
 

--- a/src/model/stateManager.js
+++ b/src/model/stateManager.js
@@ -1,5 +1,8 @@
-class StateManager {
+import EventEmitter from "events";
+
+class StateManager extends EventEmitter {
     constructor(localStorage) {
+        super()
         //localStorage.clear()
         this.localStorage = localStorage
         
@@ -22,8 +25,8 @@ class StateManager {
             customPrefix: false,
             customPrefixStr: null
         }
+        this.state = this.defaults
 
-        this.init()
     }
 
     init() {
@@ -32,74 +35,46 @@ class StateManager {
         const rawData = this.localStorage.getItem('data');
         let data = JSON.parse(rawData)
 
+        if (!data) return
+
         for (const key in this.defaults) {
-            this[key] = this.defaults[key]
-
-            if (!data) continue
-
             if (key in data) {
-                this[key] = data[key]
+                this.state[key] = data[key]
+            } else {
+                this.state[key] = this.defaults[key]
             }
         }
+    }
 
+    getState() {
+        return this.state
+    }
+    
+    setState(newState) {
+        const keys = Object.keys(newState).filter((key) => {
+            if (newState[key] !== this.state[key]) {
+                return true
+            }
+            return false
+        })
+        keys.forEach((key) => {
+            console.log(`[stateManager:setState] State changed in '${key}' (${this.state[key]} -> ${newState[key]})`)
+        })
+
+        // ignore emit stateChange if none state changed
+        if (keys.length === 0) return
+
+        this.state = { ...this.state, ...newState }
+        
         this.updateLocalStorage()
-    }
-
-    toObj() {
-        // console.log('[StateManager:toObj] Convert State to Object')
-        const data = {}
-
-        for (const key in this.defaults) {
-            data[key] = this[key]
-        }
-
-        console.log('[StateManager:toObj] Converted State to JS Object');
-        
-        return data
-    }
-
-    toJsonStr() {
-        const data = {}
-
-        for (const key in this.defaults) {
-            data[key] = this[key]
-        }
-        
-        console.log('[StateManager:toJsonStr] Converted State to JSON String')
-        return JSON.stringify(data, null, 4)
-    }
-
-    updateFromObj(obj) {
-        try {
-            console.log('[StateManager:updateFromObj] Processing update from Object data')
-
-            for (const key in this.defaults) {
-                this[key] = obj[key]
-            }
-
-            this.updateLocalStorage()
-        } catch (error) {
-            console.log('[StateManager:updateFromObj] Error while processing update' + error)
-        }
-    }
-
-    updateFromJsonStr(jsonStr) {
-        try {
-            console.log('[StateManager:updateFromJsonStr] Processing update from JSON data')
-            const data = JSON.parse(jsonStr)
-
-            this.updateFromObj(data)
-        } catch (error) {
-            console.log('[StateManager:updateFromJsonStr] Error while processing update : ' + error)
-        }
+        this.emit('stateChange', this.state)
     }
 
     updateLocalStorage() {
-        const jsonStr = this.toJsonStr()
+        const jsonStr = JSON.stringify(this.state)
         
         this.localStorage.setItem('data', jsonStr)
-        console.log(`[StateManager:updateLocalStorage] Updated localStorage data to ${jsonStr}`)
-        // console.log('[StateManager:updateLocalStorage] Updated LocalStorage');
+        console.log(`[StateManager:updateLocalStorage] Updated localStorage state`)
     }
 }
 

--- a/src/services/adobe/adobeApp.js
+++ b/src/services/adobe/adobeApp.js
@@ -24,7 +24,7 @@ class AdobeApp {
             this.appName = this.adobeAppConfig.name
             this.appImg = this.adobeAppConfig.img
 
-            console.log('[AdobeApp:load] loaded App with AppCode : ' + this.appCode)
+            console.log('[AdobeApp:load] loaded App with AppCode : ' + appCode)
         } catch (e) {
             console.log('[AdobeApp:load] Failed while load the app configuration : ' + e)
             return

--- a/src/services/adobe/adobeRPC.js
+++ b/src/services/adobe/adobeRPC.js
@@ -1,16 +1,22 @@
 import { Client } from 'discord-rpc'
 import AdobeApp from './adobeApp'
+import EventEmitter from 'events'
 
-class AdobeRPC {
+class AdobeRPC extends EventEmitter{
     constructor(stateManager) {
+        super()
+
         this.client = null
         this.callback = null
         this.interval = null
 
         this.adobeApp = new AdobeApp()
         this.stateManager = stateManager
+        this.getCurrentState = null
         this.startTimestamp = new Date()
         this.csInterface = new CSInterface()
+        this.isReconnecting = false
+        this.lastActivityInfo = null
 
         this.adobeApp.load()
 
@@ -21,76 +27,72 @@ class AdobeRPC {
         this.client = new Client({ transport: 'ipc' })
         console.log('[AdobeRPC:createNewClient] Created new RPC Client')
     }
+    
+    emitConnection(connection) {
+        this.emit('connectionChange', connection)
+    }
+    
+    emitAdobeInfo(info) {
+        this.emit('adobeInfoChange', info)
+    }
 
-    login(callback) {
-        this.callback = callback
-        if (!this.stateManager.power) {
-            this.stateManager.rpcConnection = 'disconnected'
-            callback()
+    login() {
+        if (this.isReconnecting) return
 
+        const state = this.stateManager.getState()
+        if (!state.power) {
+            this.emitConnection('disconnected')
             console.log('[AdobeRPC:login] Power is OFF. login job aborted.')
             return
         }
 
         this.createNewClient()
 
-        let isReconnecting = false
         const reconnect = () => {
-            if (!isReconnecting) {
+            const state = this.stateManager.getState()
+            if (state.power && !this.isReconnecting) {
                 console.log(`[AdobeRPC:reconnect] Reconnecting RPC after 5 sec...`)
-                this.stateManager.rpcConnection = 'connecting'
-                callback()
+                this.emitConnection('connecting')
 
                 setTimeout(() => {
                     console.log('[AdobeRPC:reconnect] Reconnecting RPC...')
-                    this.login(this.callback)
+                    this.isReconnecting = false
+
+                    this.login()
                 }, 4000)
 
-                isReconnecting = true
+                this.isReconnecting = true
                 return
             }
 
-            console.log('[AdobeRPC:reconnect] Aborted reconnect job because rpc is currently reconnecting')
+            console.log('[AdobeRPC:reconnect] Aborted reconnect')
         }
 
         this.client.once("ready", () => {
             console.log('[AdobeRPC:ready] RPC Connected!')
-            this.stateManager.rpcConnection = 'connected'
-            callback()
+            this.emitConnection('connected')
 
-            console.log('[AdobeRPC:ready] Request startPolling...')
+            console.log('[AdobeRPC:ready] Starting poll...')
             this.startPolling()
         })
         this.client.once("disconnected", () => {
-            if (this.stateManager.power) {
-                console.log('[AdobeRPC:disconnected] RPC Disconnected, request reconnect job...')
-                reconnect()
-                return
-            }
+            reconnect()
 
             console.log(`[AdobeRPC:disconnected] RPC Disconnected`)
-            this.stateManager.rpcConnection = 'disconnected'
-            callback()
+            this.emitConnection('disconnected')
         })
 
 
         console.log(`[AdobeRPC:login] Connecting with ClientID(${this.adobeApp.clientId})...`)
-        this.stateManager.rpcConnection = 'connecting'
-        callback()
+        this.emitConnection('connecting')
 
         this.client.login({
             clientId: this.adobeApp.clientId
         }).catch((err) => {
             console.log(`[AdobeRPC:loginError] Error while trying to login : ${err}`)
-            if (this.stateManager.power) {
-                console.log('[AdobeRPC:loginError] Request reconnect job...')
-                reconnect()
-                return
-            }
+            reconnect()
 
-            this.stateManager.rpcConnection = 'disconnected'
-            callback()
-
+            this.emitConnection('disconnected')
         })
     }
 
@@ -98,127 +100,137 @@ class AdobeRPC {
         this.client.clearActivity().then(() => {
             return this.client.destroy()
         }).then(() => {
-            clearInterval(this.interval)
-            this.stateManager.rpcConnection = 'disconnected'
-            this.callback()
-            console.log('[AdobeRPC:logout] Successfully logout and clear interval')
+            console.log('[AdobeRPC:logout] Successfully logout')
         }).catch((err) => {
             console.log('[AdobeRPC:logout] Error: ' + err)
+        }).finally(() => {
             clearInterval(this.interval)
-            this.stateManager.rpcConnection = 'disconnected'
-            this.callback()
+            this.emitConnection('disconnected')
         })
         
     }
 
-    executeScript(props, func) {
-        this.csInterface.evalScript(func, (r) => {
-            if (r === null) {
-                console.log("[AdobeRPC:executeScript] Aborting null response");
-                return;
-            }
-
-            if (r != this.stateManager[props]) {
-                console.log(`[AdobeRPC:executeScript] Detected changes (${this.stateManager[props]} -> ${r})`)
-                this.stateManager[props] = r;
-
-                this.updateActivity();
-            }
-        })
-    }
-
-    updateActivity() {
-        console.log('[AdobeRPC:updateActivity] Begin update...')
-        if (this.stateManager.rpcConnection == "disconnected" || this.stateManager.rpcConnection == "connecting") {
-            console.log('[AdobeRPC:updateActivity] RPC is not connected, aborted job.')
-            return
-        }
-        if (!this.stateManager.power) {
-            console.log('[AdobeRPC:updateActivity] RPC Power is OFF, aborted job.')
-            return
-        }
-
+    setActivity(state) {
         const activity = {
             startTimestamp: this.startTimestamp,
             largeImageKey: this.adobeApp.appImg,
             largeImageText: this.adobeApp.appName,
         }
 
-        if (this.stateManager.rpcDetails && this.stateManager.showDetails) {
-            activity.details = this.stateManager.rpcDetails;
+        if (state.rpcDetails && state.showDetails) {
+            activity.details = state.rpcDetails;
         }
 
-        if (this.stateManager.rpcState && this.stateManager.showState) {
+        if (state.rpcState && state.showState) {
             let stateStr = ""
 
-            if (this.stateManager.customPrefix && this.stateManager.customPrefixStr) {
-                stateStr += this.stateManager.customPrefixStr + " "
+            if (state.customPrefix && state.customPrefixStr) {
+                stateStr += state.customPrefixStr + " "
             } else {
                 stateStr += "Working on "
             }
 
-            stateStr += this.stateManager.rpcState
+            if (state.rpcState === 'Idling.') {
+                stateStr = state.rpcState
+            } else {
+                stateStr += state.rpcState
+            }
 
             activity.state = stateStr;
         }
 
-        if (this.stateManager.rpcSmallImageKey) {
-            activity.smallImageKey = this.stateManager.rpcSmallImageKey
+        if (state.rpcSmallImageKey) {
+            activity.smallImageKey = state.rpcSmallImageKey
         }
 
-        if (this.stateManager.rpcPartySize && this.stateManager.rpcPartyMax) {
-            activity.partySize = parseInt(this.stateManager.rpcPartySize)
-            activity.partyMax = parseInt(this.stateManager.rpcPartyMax)
+        if (state.rpcPartySize && state.rpcPartyMax) {
+            activity.partySize = parseInt(state.rpcPartySize)
+            activity.partyMax = parseInt(state.rpcPartyMax)
         }
 
-        if (this.stateManager.customImage && this.stateManager.customImageURL) {
-            activity.largeImageKey = this.stateManager.customImageURL
+        if (state.customImage && state.customImageURL) {
+            activity.largeImageKey = state.customImageURL
         }
 
-        console.log('[AdobeRPC:updateActivity] Updating activity to ' + JSON.stringify(activity, null, 4))
+        if (this.lastActivityInfo && JSON.stringify(this.lastActivityInfo) === JSON.stringify(activity)) {
+            console.log('[AdobeRPC:updateActivity] Aborted setActivity request')
+            return
+        }
 
         this.client.setActivity(activity).catch((err) => {
-            console.log(`[AdobeRPC:updateActivity] Failed updating activity : ${err}`)
+            console.log(`[AdobeRPC:updateActivity] Failed to update activity : ${err}`)
         }).then(() => {
-            console.log(`[AdobeRPC:updateActivity] Update Finished.`)
-
-            // Update view state
-            this.callback()
+            console.log('[AdobeRPC:updateActivity] Set activity to: ' + JSON.stringify(activity, null, 4))
+            this.lastActivityInfo = activity
         });
     }
 
+    async executeScript(func) {
+        return new Promise((resolve) => {
+            this.csInterface.evalScript(func, (r) => {
+                resolve(r)
+            })
+        })
+        
+    }
+    
     startPolling() {
-        this.updateActivity()
-        this.interval = setInterval(() => {
-            // Return if RPC Connection is disconnected or connecting
-            if (this.stateManager.rpcConnection == "disconnected" || this.stateManager.rpcConnection == "connecting") return
+        const funcs = [
+            { props: 'rpcDetails', func: 'getDetails()' },
+            { props: 'rpcState', func: 'getState()' },
+            { props: 'rpcSmallImageKey', func: 'getSmallImageKey()' },
+            { props: 'rpcPartySize', func: 'getPartySize()' },
+            { props: 'rpcPartyMax', func: 'getPartyMax()' },
+        ]
 
-            this.executeScript('rpcDetails', 'getDetails()');
-            this.executeScript('rpcState', 'getState()');
-            this.executeScript('rpcSmallImageKey', 'getSmallImageKey()');
-            this.executeScript('rpcPartySize', 'getPartySize()');
-            this.executeScript('rpcPartyMax', 'getPartyMax()');
+        this.interval = setInterval(async () => {
+            let isChanged = false
+
+            const state = this.stateManager.getState()
+            const responses = []
+            
+            for (const func of funcs) {
+                const response = await this.executeScript(func.func)
+                responses.push({ props: func.props, response: response })
+            }
+            
+            const adobeInfo = {}
+            responses.forEach((response) => {
+                if (state[response.props] !== response.response) {
+                    console.log(`[AdobeRPC:Polling] Detected changes in '${response.props}' (${state[response.props]} -> ${response.response})`)
+                    adobeInfo[response.props] = response.response
+                    isChanged = true
+                }
+            })
+            
+            if (isChanged) {
+                this.emit('adobeInfoChange', adobeInfo)
+            }
         }, 1000)
 
         console.log('[AdobeRPC:startPolling] Polling Started')
     }
 
-    reload() {
-        if (!this.stateManager.power && this.stateManager.rpcConnection == "connected") {
-            console.log("[AdobeRPC:reload] Power is OFF but rpc connection is connected, logged out...")
-            clearInterval(this.interval)
+    reload(state) {
+        if (!state.power && state.rpcConnection === "connected") {
+            console.log("[AdobeRPC:reload] Power is OFF but rpc connection is connected, disconnecting RPC...")
             this.logout()
         }
 
-        if (this.stateManager.power && this.stateManager.rpcConnection == "disconnected") {
-            console.log("[AdobeRPC:reload] Power is ON but rpc connection is disconnected, logged in...")
-            this.login(this.callback)
+        if (state.power && state.rpcConnection === "disconnected") {
+            console.log("[AdobeRPC:reload] Power is ON but rpc connection is disconnected, connecting RPC...")
+            this.login()
         }
 
-        if (this.stateManager.power) {
-            console.log('[AdobeRPC:reload] Run updateActivity...')
-            this.updateActivity()
+        if (state.power && state.rpcConnection === "connected") {
+            console.log('[AdobeRPC:reload] Updating RPC activity...')
+            this.setActivity(state)
         }
+    }
+    
+    startService() {
+        this.login()
+        this.stateManager.on('stateChange', (state) => this.reload(state))
     }
 }
 

--- a/src/services/event/stateEvent.js
+++ b/src/services/event/stateEvent.js
@@ -1,26 +1,30 @@
-class StateEvent {
-    constructor(stateManager) {
-        this.csInterface = new CSInterface()
-        this.stateEvent = new CSEvent('com.kureichi.rpc.state-from-backend', 'APPLICATION')
+import EventEmitter from "events"
+
+class StateEvent extends EventEmitter {
+    constructor(stateManager, csInterface) {
+        super()
+
         this.stateManager = stateManager
+        this.csInterface = csInterface
+        this.stateEvent = new CSEvent('com.kureichi.rpc.state-from-backend', 'APPLICATION')
+        
+        this.stateManager.on('stateChange', (state) => this.dispatchEvent(state))
+        
     }
 
-    registerListener(callback) {
-        this.csInterface.addEventListener('com.kureichi.rpc.get-state', () => this.dispatchEvent())
+    registerListener() {
+        this.csInterface.addEventListener('com.kureichi.rpc.get-state', () => this.dispatchEvent(this.stateManager.getState()))
+
+        console.log('[StateEvent:registerListener] Registered Listener Event.')
 
         this.csInterface.addEventListener('com.kureichi.rpc.state-from-view', (r) => {
             console.log('[StateEvent:Listener] Got State from View')
-            this.stateManager.updateFromObj(r.data)
-            this.dispatchEvent()
-
-            callback()
+            this.emit('stateFromView', r.data)
         })
-
-        console.log('[StateEvent:registerListener] Registered Listener Event.')
     }
 
-    dispatchEvent() {
-        this.stateEvent.data = this.stateManager.toJsonStr()
+    dispatchEvent(state) {
+        this.stateEvent.data = JSON.stringify(state)
         this.csInterface.dispatchEvent(this.stateEvent)
 
         console.log('[StateEvent:dispatchEvent] Dispatched event')

--- a/src/services/github/versionCheck.js
+++ b/src/services/github/versionCheck.js
@@ -11,44 +11,39 @@ class VersionCheck {
         this.manifestReader = new ManifestReader()
     }
 
-    check(callback) {
+    async getVersion() {
         this.manifestReader.load()
         this.currentVersion = this.manifestReader.getManifestVersion()
 
         this.currentVersionStr = 'v' + this.currentVersion
 
-        fetch(`${this.repoUrl}/releases/latest`).then((response) => {
-            console.log('[VersionCheck:check] Fetched Repository to check version')
-            if (response.ok) {
-                console.log('[VersionCheck:check] Response is OK')
-                response.json().then((data) => {
-                    console.log('[VersionCheck:check] Data is convert to JSON')
+        try {
+            console.log('[VersionCheck:check] Checking latest version...')
 
-                    const latestVersion = data.tag_name;
-                    if (parseInt(latestVersion) > parseInt(this.currentVersion)) {
-                        console.log(`[VersionCheck:check] Version (${this.currentVersionStr}) is outdated, consider to update (to ${latestVersion})`)
-
-                        this.isLatestVersion = false
-                        callback(`New Update ${latestVersion} ↗`)
-                        return
-                    }
-
-                    console.log(`[VersionCheck:check] This is latest version (${this.currentVersion})`)
-
-                    this.isLatestVersion = true
-                    callback(this.currentVersionStr)
-                    return
-                })
-
-                return
+            const response = await fetch(`${this.repoUrl}/releases/latest`)
+            if (!response.ok) {
+                console.log('[VersionCheck:check] Response not ok, retrying...');
+                setTimeout(() => this.check(), 3000);
             }
 
-            console.log('[VersionCheck:check] Response not ok, retrying...');
-            setTimeout(() => this.check(callback), 3000);
-        }).catch(() => {
+            console.log('[VersionCheck:check] Response is OK')
+            const data = await response.json()
+
+            const latestVersion = data.tag_name;
+            if (parseInt(latestVersion) > parseInt(this.currentVersion)) {
+                console.log(`[VersionCheck:check] Version (${this.currentVersionStr}) is outdated, consider to update (to ${latestVersion})`)
+
+                this.isLatestVersion = false
+                return `New Update ${latestVersion} ↗`
+            }
+
+            console.log(`[VersionCheck:check] This is latest version (${this.currentVersion})`)
+            this.isLatestVersion = true
+            return this.currentVersionStr
+        } catch(e) {
             console.log('Panel:: Error while trying to fetch api, ' + e);
-            setTimeout(() => this.check(callback), 5000);
-        })
+            setTimeout(() => this.check(), 5000);
+        }
     }
 }
 

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -75,8 +75,7 @@ class App {
                 newModel.customPrefixStr = customPrefixStr.value
                 break
             case this.Msg.powerButtonClick:
-                const currentPower = currentState.power
-                newModel.power = currentPower ? false : true
+                newModel.power = currentState.power ? false : true
                 break
             default:
                 console.log('[App:Update] Msg not match')
@@ -150,10 +149,11 @@ class App {
 function main() {
     const app = new App()
     const stateManager = new StateManager(localStorage)
+    stateManager.init()
 
     // we decided to use the state object instead of updating directly to the state class
     // update: Nah we'll use statemanager instance class
-    let currentState = stateManager
+    let currentState = stateManager.getState()
 
     csInterface.addEventListener('com.kureichi.rpc.state-from-backend', (r) => {
         console.log('[Main:listener] Got State from backend, received with value : ' + JSON.stringify(r.data, null, 4))


### PR DESCRIPTION
now everything is more organized and structured. RPC will only reload if the global state changes, and the same applies to dispatching state events to the frontend (view)

polling has also been streamlined. now, `updateActivity` will run only after all `evalScript`s have executed, and `updateActivity` will set the activity only if the activity state has changed